### PR TITLE
switch to latest san lib, print san exception, update doc, remove ext…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.secret
 data/
 *.code-workspace
+*.swp

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cp settings/data_generator.example data_generator.secret
 vi data_generator.secret
 ```
 
-Make sure to set `oer` and `cmc`.
+Make sure to set `oer` (which is a valid Open Exchange Rate app_id) and `san` (which is a Santiment api_key).
 
 ### image_generator
 

--- a/data_generator/requirements.txt
+++ b/data_generator/requirements.txt
@@ -2,6 +2,6 @@ aiocache==0.11.1
 aiofiles==0.4.0
 httpx==0.11.1
 jinja2==2.11.1
-https://github.com/blockchainunchained/sanpy/archive/c57abc4db9ab2d480d88672984d981923359db39.tar.gz
+sanpy==0.8.6
 starlette==0.13.2
 uvicorn==0.11.3


### PR DESCRIPTION
…ra ws

Not sure why there was a older, local copy of san library. But, it was out of date. 0.7 vs 0.8.
Not sure why `await` was on the san.get(). (It may be wrong to remove it, but it does seem to work ok.)
Added exception handling to the san.get() call. You can see how this would work if you add a non-valid field in the DEFAULT_SAN_FIELDS list.

The code before and after this change seems to work, based on my local testing.

Let me know if I can help further.